### PR TITLE
Check type of tag before preventing default

### DIFF
--- a/dist/clicktap.js
+++ b/dist/clicktap.js
@@ -47,7 +47,10 @@ function clicktap(el, listener, capture) {
   function fn(eve) {
     if (pointerCanceled) { pointerCanceled = false; return; }
     listener.call(el, eve);
-    eve.preventDefault();
+
+    if (eve.target.tagName === 'A') {
+      eve.preventDefault();
+    }
   }
 
   listener.fn = fn;

--- a/dist/clicktap.js
+++ b/dist/clicktap.js
@@ -51,7 +51,11 @@ function clicktap(el, listener, capture) {
 
   listener.fn = fn;
 
-  el.addEventListener(touch.end, listener.fn, capture || false);
+  // hack for avoiding catching IE's touchend AND click events
+  if (!window.navigator.msPointerEnabled) {
+    el.addEventListener(touch.end, listener.fn, capture || false);
+  }
+
   el.addEventListener('click', listener.fn, capture || false);
 
   return clicktap;

--- a/dist/clicktap.js
+++ b/dist/clicktap.js
@@ -47,10 +47,6 @@ function clicktap(el, listener, capture) {
   function fn(eve) {
     if (pointerCanceled) { pointerCanceled = false; return; }
     listener.call(el, eve);
-
-    if (eve.target.tagName === 'A') {
-      eve.preventDefault();
-    }
   }
 
   listener.fn = fn;


### PR DESCRIPTION
I think the default behaviour of the browser should only be prevented if the clicked element is an anchor. In my case, I was having trouble with Checkboxes that wouldn't get checked anymore because I was using Clicktap on them to trigger some additional JS.
